### PR TITLE
amd_hsmp: add module compatibility with old linux kernels #3 #4

### DIFF
--- a/amd_hsmp.c
+++ b/amd_hsmp.c
@@ -366,7 +366,7 @@ static int __init hsmp_plt_init(void)
 	u16 num_sockets;
 	int i;
 
-	if (boot_cpu_data.x86_vendor != X86_VENDOR_AMD || boot_cpu_data.x86 < 0x19) {
+	if (boot_cpu_data.x86_vendor != X86_VENDOR_AMD || boot_cpu_data.x86 < 0x17) {
 		pr_err("HSMP is not supported on Family:%x model:%x\n",
 		       boot_cpu_data.x86, boot_cpu_data.x86_model);
 		return ret;

--- a/amd_hsmp.c
+++ b/amd_hsmp.c
@@ -260,8 +260,11 @@ static long hsmp_ioctl(struct file *fp, unsigned int cmd, unsigned long arg)
 	int __user *arguser = (int  __user *)arg;
 	struct hsmp_message msg = { 0 };
 	int ret;
-
+#ifdef copy_struct_from_user 
 	if (copy_struct_from_user(&msg, sizeof(msg), arguser, sizeof(struct hsmp_message)))
+#else
+	if (copy_from_user(&msg, arguser, sizeof(struct hsmp_message)))
+#endif
 		return -EFAULT;
 
 	/*


### PR DESCRIPTION
Solves the issue #3 and #4 as @nchatrad suggested.