### PR TITLE
Fix dkms errors on Debian

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -16,7 +16,8 @@ family_hex=$(printf "0x%x" "$family")
 model_hex=$(printf "0x%x" "$model")
 
 # Perform the comparison
-if [ "$family_hex" = "0x19" ] && [ "$model_hex" -ge "0x00" ] && [ "$model_hex" -le "0x1f" ]; then
+# sh can only compare decimal numbers, not hex, so use 31 instead of 0x1f for the model
+if [ "$family_hex" = "0x19" ] && [ "$model" -ge "0" ] && [ "$model" -le "31" ]; then
        BUILT_MODULE_NAME[1]="amd_hsmp"
 else
        BUILT_MODULE_NAME[1]="hsmp_acpi"


### PR DESCRIPTION
Debian dkms uses sh = dash. dash doesn't support hex number comparison