### PR TITLE
platform/x86/amd/hsmp: Add support for variable-sized metrics tables

### DIFF
--- a/acpi.c
+++ b/acpi.c
@@ -584,24 +584,12 @@ static int init_acpi(struct device *dev)
 	return ret;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-static const struct bin_attribute  hsmp_metric_tbl_attr = {
-#else
-static struct bin_attribute  hsmp_metric_tbl_attr = {
-#endif
+static HSMP_CONST struct bin_attribute hsmp_metric_tbl_attr = {
 	.attr = { .name = HSMP_METRICS_TABLE_NAME, .mode = 0444},
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-	.read_new = hsmp_metric_tbl_acpi_read,
-#else
-	.read = hsmp_metric_tbl_acpi_read,
-#endif
+	HSMP_BIN_READ = hsmp_metric_tbl_acpi_read,
 };
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-static const struct bin_attribute *hsmp_attr_list[] = {
-#else
-static struct bin_attribute *hsmp_attr_list[] = {
-#endif
+static HSMP_CONST struct bin_attribute *hsmp_attr_list[] = {
 	&hsmp_metric_tbl_attr,
 	NULL
 };
@@ -647,16 +635,8 @@ static struct attribute *hsmp_dev_attr_list[] = {
 	NULL
 };
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-static const struct attribute_group hsmp_attr_grp = {
-#else
-static struct attribute_group hsmp_attr_grp = {
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-	.bin_attrs_new = hsmp_attr_list,
-#else
-	.bin_attrs = hsmp_attr_list,
-#endif
+static HSMP_CONST struct attribute_group hsmp_attr_grp = {
+	HSMP_BIN_ATTRS_FIELD = hsmp_attr_list,
 	.attrs = hsmp_dev_attr_list,
 	.is_bin_visible = hsmp_is_sock_attr_visible,
 	.is_visible = hsmp_is_sock_dev_attr_visible,

--- a/acpi.c
+++ b/acpi.c
@@ -262,7 +262,7 @@ static ssize_t hsmp_metric_tbl_acpi_read(struct file *filp, struct kobject *kobj
 	struct device *dev = container_of(kobj, struct device, kobj);
 	struct hsmp_socket *sock = dev_get_drvdata(dev);
 
-	return hsmp_metric_tbl_read(sock, buf, count);
+	return hsmp_metric_tbl_read(sock, buf, count, off);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
@@ -273,7 +273,8 @@ static umode_t hsmp_is_sock_attr_visible(struct kobject *kobj,
 					 struct bin_attribute *battr, int id)
 #endif
 {
-	if (hsmp_pdev->proto_ver == HSMP_PROTO_VER6)
+	if (hsmp_pdev->proto_ver == HSMP_PROTO_VER6 ||
+	    hsmp_pdev->proto_ver == HSMP_PROTO_VER7)
 		return battr->attr.mode;
 
 	return 0;
@@ -567,7 +568,8 @@ static int init_acpi(struct device *dev)
 		return ret;
 	}
 
-	if (hsmp_pdev->proto_ver == HSMP_PROTO_VER6) {
+	if (hsmp_pdev->proto_ver == HSMP_PROTO_VER6 ||
+	    hsmp_pdev->proto_ver == HSMP_PROTO_VER7) {
 		ret = hsmp_get_tbl_dram_base(sock_ind);
 		if (ret)
 			dev_err(dev, "Failed to init metric table\n");
@@ -593,7 +595,6 @@ static struct bin_attribute  hsmp_metric_tbl_attr = {
 #else
 	.read = hsmp_metric_tbl_acpi_read,
 #endif
-	.size = sizeof(struct hsmp_metric_table),
 };
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)

--- a/amd_hsmp.h
+++ b/amd_hsmp.h
@@ -583,6 +583,92 @@ struct hsmp_metric_table {
 	__u32 gfxclk_frequency[8];
 };
 
+#define F1A_M50_M5F_MAX_CORES_PER_CCD_32	32
+#define F1A_M50_M5F_MAX_FREQ_TABLE_SIZE		4
+#define F1A_M50_M5F_MAX_XGMI			8
+#define F1A_M50_M5F_MAX_PCIE			8
+#define F1A_M50_M5F_MAX_CCD			8
+
+/* Metrics table (supported only with proto version 7) */
+struct hsmp_metric_table_f1a_m50_5f_iod {
+	__u32 num_active_ccds;
+	__u32 accumulation_counter;
+
+	/* TEMPERATURE */
+	__u64 max_socket_temperature_acc;
+
+	/* POWER */
+	__u32 socket_power_limit;
+	__u32 max_socket_power_limit;
+	__u64 socket_power_acc;
+	__u64 core_power_acc;
+	__u64 uncore_power_acc;
+
+	/* ENERGY */
+	__u64 timestamp;
+	__u64 socket_energy_acc;
+	__u64 core_energy_acc;
+	__u64 uncore_energy_acc;
+
+	/* FREQUENCY */
+	__u64 fclk_frequency_acc;
+	__u64 uclk_frequency_acc;
+	__u64 ddr_rate_acc;
+	__u64 lclk_frequency_acc[F1A_M50_M5F_MAX_FREQ_TABLE_SIZE];
+
+	/* FREQUENCY RANGE */
+	__u32 fclk_frequency_table[F1A_M50_M5F_MAX_FREQ_TABLE_SIZE];
+	__u32 uclk_frequency_table[F1A_M50_M5F_MAX_FREQ_TABLE_SIZE];
+	__u32 ddr_rate_table[F1A_M50_M5F_MAX_FREQ_TABLE_SIZE];
+	__u32 max_df_pstate_range;
+	__u32 min_df_pstate_range;
+	__u32 lclk_frequency_table[F1A_M50_M5F_MAX_FREQ_TABLE_SIZE];
+	__u32 max_lclk_dpm_range;
+	__u32 min_lclk_dpm_range;
+
+	/* XGMI */
+	__u64 xgmi_bit_rate[F1A_M50_M5F_MAX_XGMI];
+	__u64 xgmi_read_bandwidth[F1A_M50_M5F_MAX_XGMI];
+	__u64 xgmi_write_bandwidth[F1A_M50_M5F_MAX_XGMI];
+
+	/* ACTIVITY */
+	__u64 socket_c0_residency_acc;
+	__u64 socket_df_cstate_residency_acc;
+	__u64 dram_read_bandwidth_acc;
+	__u64 dram_write_bandwidth_acc;
+	__u32 max_dram_bandwidth;
+	__u64 pcie_bandwidth_acc[F1A_M50_M5F_MAX_PCIE];
+
+	/* THROTTLERS */
+	__u32 prochot_residency_acc;
+	__u32 ppt_residency_acc;
+	__u32 thm_residency_acc;
+	__u32 vrhot_residency_acc;
+	__u32 cpu_tdc_residency_acc;
+	__u32 soc_tdc_residency_acc;
+	__u32 io_mem_tdc_residency_acc;
+	__u32 fit_residency_acc;
+};
+
+struct hsmp_metric_table_f1a_m50_5f_ccd {
+	__u32 core_apicid_of_thread0[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_c0[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_cc1[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_cc6[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_frequency[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_frequency_effective[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+	__u64 core_power[F1A_M50_M5F_MAX_CORES_PER_CCD_32];
+};
+
+/*
+ * Future processors within the same family and model may support a
+ * variable number of CCDs and cores
+ */
+struct hsmp_metric_table_f1a_m50_5f {
+	struct hsmp_metric_table_f1a_m50_5f_iod	iod;
+	struct hsmp_metric_table_f1a_m50_5f_ccd	ccd[F1A_M50_M5F_MAX_CCD];
+};
+
 /* Reset to default packing */
 #pragma pack()
 

--- a/hsmp.c
+++ b/hsmp.c
@@ -368,29 +368,48 @@ long hsmp_ioctl(struct file *fp, unsigned int cmd, unsigned long arg)
 	return 0;
 }
 
-ssize_t hsmp_metric_tbl_read(struct hsmp_socket *sock, char *buf, size_t size)
+/**
+ * hsmp_metric_tbl_read - Read metric table
+ *
+ * This function maintains ABI compatibility for external consumers.
+ * It reads from offset 0, which works for all metrics table formats.
+ * External modules using this function will continue to work without
+ * modification.
+ *
+ * Return: number of bytes read or negative error code
+ */
+
+ssize_t hsmp_metric_tbl_read(struct hsmp_socket *sock, char *buf,
+			     size_t size, loff_t off)
 {
 	struct hsmp_message msg = { 0 };
+	size_t var_size, remaining;
 	int ret;
 
 	if (!sock || !buf)
 		return -EINVAL;
 
-	/* Do not support lseek(), also don't allow more than the size of metric table */
-	if (size != sizeof(struct hsmp_metric_table)) {
-		dev_err(sock->dev, "Wrong buffer size\n");
+	if (off < 0 || off > hsmp_pdev.hsmp_table_size) {
+		dev_err(sock->dev, "Invalid offset\n");
 		return -EINVAL;
 	}
 
-	msg.msg_id	= HSMP_GET_METRIC_TABLE;
-	msg.sock_ind	= sock->sock_ind;
+	/* Compute remaining bytes using explicit cast to avoid signed/unsigned mixing */
+	remaining = hsmp_pdev.hsmp_table_size - (size_t)off;
+	var_size = min_t(size_t, size, remaining);
+	if (off == 0) {
+		msg.msg_id	= HSMP_GET_METRIC_TABLE;
+		msg.sock_ind	= sock->sock_ind;
 
-	ret = hsmp_send_message(&msg);
-	if (ret)
+		ret = hsmp_send_message(&msg);
+		if (ret) {
+			dev_err(sock->dev, "Failed to send HSMP_GET_METRIC_TABLE, ret: %d\n", ret);
 		return ret;
-	memcpy_fromio(buf, sock->metric_tbl_addr, size);
+		}
+	}
+	memcpy_fromio(buf, (u8 __iomem *)sock->metric_tbl_addr + off, var_size);
 
-	return size;
+	return var_size;
 }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 EXPORT_SYMBOL_NS_GPL(hsmp_metric_tbl_read, "AMD_HSMP");
@@ -401,8 +420,10 @@ EXPORT_SYMBOL_NS_GPL(hsmp_metric_tbl_read, AMD_HSMP);
 int hsmp_get_tbl_dram_base(u16 sock_ind)
 {
 	struct hsmp_socket *sock = &hsmp_pdev.sock[sock_ind];
+	struct hsmp_message msg_tbl_ver = { 0 };
 	struct hsmp_message msg = { 0 };
 	phys_addr_t dram_addr;
+	u32 table_ver;
 	int ret;
 
 	msg.sock_ind	= sock_ind;
@@ -422,8 +443,44 @@ int hsmp_get_tbl_dram_base(u16 sock_ind)
 		dev_err(sock->dev, "Invalid DRAM address for metric table\n");
 		return -ENOMEM;
 	}
-	sock->metric_tbl_addr = devm_ioremap(sock->dev, dram_addr,
-					     sizeof(struct hsmp_metric_table));
+
+	/* Get metric table version */
+	msg_tbl_ver.sock_ind    = sock_ind;
+	msg_tbl_ver.response_sz = hsmp_msg_desc_table[HSMP_GET_METRIC_TABLE_VER].response_sz;
+	msg_tbl_ver.msg_id      = HSMP_GET_METRIC_TABLE_VER;
+
+	ret = hsmp_send_message(&msg_tbl_ver);
+	if (ret)
+		return ret;
+
+	table_ver = msg_tbl_ver.args[0];
+
+	hsmp_pdev.hsmp_table_size = 0;
+	/* Determine metric table size based on CPU family/model and table version */
+	switch (boot_cpu_data.x86) {
+	case 0x1A:
+		if (boot_cpu_data.x86_model >= 0x50 &&
+		    boot_cpu_data.x86_model <= 0x5F &&
+		    table_ver == 0x00700000) {
+			hsmp_pdev.hsmp_table_size = sizeof(struct hsmp_metric_table_f1a_m50_5f);
+		}
+		break;
+	case 0x19:
+		if (boot_cpu_data.x86_model >= 0x90 &&
+		    boot_cpu_data.x86_model <= 0x9F) {
+			hsmp_pdev.hsmp_table_size = sizeof(struct hsmp_metric_table);
+		}
+		break;
+	}
+
+	if (!hsmp_pdev.hsmp_table_size) {
+		dev_err(sock->dev,
+			"Metric table not supported for F%02Xh_M%02Xh (table version: 0x%08X)\n",
+			boot_cpu_data.x86, boot_cpu_data.x86_model, table_ver);
+		return -EOPNOTSUPP;
+	}
+
+	sock->metric_tbl_addr = devm_ioremap(sock->dev, dram_addr, hsmp_pdev.hsmp_table_size);
 	if (!sock->metric_tbl_addr) {
 		dev_err(sock->dev, "Failed to ioremap metric table addr\n");
 		return -ENOMEM;

--- a/hsmp.h
+++ b/hsmp.h
@@ -19,6 +19,26 @@
 #include <linux/semaphore.h>
 #include <linux/sysfs.h>
 
+/*
+ * Helper macros to handle API changes across kernel versions:
+ * - Kernels >= 6.14.0: bin_attribute and attribute_group become const
+ * - Kernels 6.14.0 to 6.17.x: use .read_new and .bin_attrs_new
+ * - Kernels < 6.14.0 and >= 6.18.0: use .read and .bin_attrs
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+#define HSMP_CONST		const
+#else
+#define HSMP_CONST
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+#define HSMP_BIN_READ		.read_new
+#define HSMP_BIN_ATTRS_FIELD	.bin_attrs_new
+#else
+#define HSMP_BIN_READ		.read
+#define HSMP_BIN_ATTRS_FIELD	.bin_attrs
+#endif
+
 #define HSMP_METRICS_TABLE_NAME	"metrics_bin"
 
 #define HSMP_ATTR_GRP_NAME_SIZE	10

--- a/hsmp.h
+++ b/hsmp.h
@@ -58,6 +58,7 @@ struct hsmp_plat_device {
 	u32 proto_ver;
 	u16 num_sockets;
 	bool is_probed;
+	size_t hsmp_table_size;
 };
 
 int hsmp_cache_proto_ver(u16 sock_ind);
@@ -66,7 +67,7 @@ long hsmp_ioctl(struct file *fp, unsigned int cmd, unsigned long arg);
 void hsmp_misc_deregister(void);
 int hsmp_misc_register(struct device *dev);
 int hsmp_get_tbl_dram_base(u16 sock_ind);
-ssize_t hsmp_metric_tbl_read(struct hsmp_socket *sock, char *buf, size_t size);
+ssize_t hsmp_metric_tbl_read(struct hsmp_socket *sock, char *buf, size_t size, loff_t off);
 struct hsmp_plat_device *get_hsmp_pdev(void);
 #if IS_ENABLED(CONFIG_HWMON)
 int hsmp_create_sensor(struct device *dev, u16 sock_ind);

--- a/plat.c
+++ b/plat.c
@@ -119,30 +119,18 @@ static umode_t hsmp_is_sock_attr_visible(struct kobject *kobj,
  * to create sysfs groups for sockets.
  * is_bin_visible function is used to show / hide the necessary groups.
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 #define HSMP_BIN_ATTR(index, _list)					\
-static const struct bin_attribute attr##index = {			\
+static HSMP_CONST struct bin_attribute attr##index = {			\
 	.attr = { .name = HSMP_METRICS_TABLE_NAME, .mode = 0444},	\
 	.private = (void *)index,					\
-	.read_new = hsmp_metric_tbl_plat_read,				\
+	HSMP_BIN_READ = hsmp_metric_tbl_plat_read,			\
 	.size = sizeof(struct hsmp_metric_table),			\
 };									\
-static const struct bin_attribute _list[] = {					\
+static HSMP_CONST struct bin_attribute _list[] = {			\
 	&attr##index,							\
 	NULL								\
 }
-#else
-#define HSMP_BIN_ATTR(index, _list)					\
-static struct bin_attribute attr##index = {				\
-	.attr = { .name = HSMP_METRICS_TABLE_NAME, .mode = 0444},	\
-	.private = (void *)index,					\
-	.read = hsmp_metric_tbl_plat_read,				\
-};									\
-static struct bin_attribute _list[] = {					\
-	&attr##index,							\
-	NULL								\
-}
-#endif
+
 HSMP_BIN_ATTR(0, *sock0_attr_list);
 HSMP_BIN_ATTR(1, *sock1_attr_list);
 HSMP_BIN_ATTR(2, *sock2_attr_list);
@@ -153,21 +141,12 @@ HSMP_BIN_ATTR(6, *sock6_attr_list);
 HSMP_BIN_ATTR(7, *sock7_attr_list);
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-#define HSMP_BIN_ATTR_GRP(index, _list, _name)					\
-static const struct attribute_group sock##index##_attr_grp = {		\
-	.bin_attrs_new = _list,					\
+#define HSMP_BIN_ATTR_GRP(index, _list, _name)				\
+static HSMP_CONST struct attribute_group sock##index##_attr_grp = {	\
+	HSMP_BIN_ATTRS_FIELD = _list,					\
 	.is_bin_visible = hsmp_is_sock_attr_visible,			\
-	.name = #_name,				\
+	.name = #_name,						\
 }
-#else
-#define HSMP_BIN_ATTR_GRP(index, _list, _name)					\
-static struct attribute_group sock##index##_attr_grp = {		\
-	.bin_attrs = _list,					\
-	.is_bin_visible = hsmp_is_sock_attr_visible,			\
-	.name = #_name,				\
-}
-#endif
 
 HSMP_BIN_ATTR_GRP(0, sock0_attr_list, socket0);
 HSMP_BIN_ATTR_GRP(1, sock1_attr_list, socket1);

--- a/plat.c
+++ b/plat.c
@@ -84,7 +84,7 @@ static ssize_t hsmp_metric_tbl_plat_read(struct file *filp, struct kobject *kobj
 
 	sock = &hsmp_pdev->sock[sock_ind];
 
-	return hsmp_metric_tbl_read(sock, buf, count);
+	return hsmp_metric_tbl_read(sock, buf, count, off);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
@@ -137,7 +137,6 @@ static struct bin_attribute attr##index = {				\
 	.attr = { .name = HSMP_METRICS_TABLE_NAME, .mode = 0444},	\
 	.private = (void *)index,					\
 	.read = hsmp_metric_tbl_plat_read,				\
-	.size = sizeof(struct hsmp_metric_table),			\
 };									\
 static struct bin_attribute _list[] = {					\
 	&attr##index,							\


### PR DESCRIPTION
Add support for the new metrics table format introduced in AMD Family 1Ah Model 50h-5Fh processors with HSMP protocol version 7.

Use CPU family/model and protocol versions to map respective variable-sized metric table configurations.
The exported hsmp_metric_tbl_read() function provides offset support for variable-sized tables.
